### PR TITLE
Migrate Dockerfile to use Mariadb 10.5 on Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
-FROM mariadb:10.5
+FROM yobasystems/alpine-mariadb:10.4.13
 
 LABEL maintainer="team@appwrite.io"
 
 # Add appwrite schema and tables
 ADD ./all.sql /docker-entrypoint-initdb.d/all.sql
-
-RUN chown -R mysql:mysql /docker-entrypoint-initdb.d/


### PR DESCRIPTION
This PR is to migrate the Dockerfile from Ubuntu based to Alpine based. The size difference is:

- 356MB for existing Ubuntu based image
- 217MB for the new Alpine based image in PR

The new Dockerfile is based off of this [Mariadb 10.5 image by yobasystems](https://github.com/yobasystems/alpine-mariadb/blob/master/alpine-mariadb-amd64/Dockerfile) as [listed here](https://hub.docker.com/r/yobasystems/alpine-mariadb).

There is a related [PR in appwrite main project](https://github.com/appwrite/appwrite/pull/550) to remove the `mysqld` command in `docker-compose.yml` since it causes restarts.