### PR TITLE
Update mariadb to v10.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mariadb:10.5.8
+FROM mariadb:10.6.0
 
 LABEL maintainer="team@appwrite.io"
 

--- a/README.md
+++ b/README.md
@@ -33,15 +33,15 @@ This container supports all environment variables supplied by the official Maria
 ### Build
 
 ```bash
-docker build --tag appwrite/mariadb:1.2.0 .
+docker build --tag appwrite/mariadb:1.3.0 .
 
-docker push appwrite/mariadb:1.2.0
+docker push appwrite/mariadb:1.3.0
 ```
 
 Multi-arch build (experimental using [buildx](https://github.com/docker/buildx)):
 
 ```
-docker buildx build --platform linux/amd64,linux/arm64/v8,linux/ppc64le --tag appwrite/mariadb:1.2.0 --push .
+docker buildx build --platform linux/amd64,linux/arm64/v8,linux/ppc64le --tag appwrite/mariadb:1.3.0 --push .
 ```
 
 ## Find Us


### PR DESCRIPTION
This PR updates:
- **mariadb**: v10.5.8 to v10.6.0
- **appwrite/mariadb**: v1.2.0 to v1.3.0