### PR TITLE
Update MariaDB to GA release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mariadb:10.6.0
+FROM mariadb:10.6.4
 
 LABEL maintainer="team@appwrite.io"
 


### PR DESCRIPTION
The current version used by AppWrite (10.6.0) is an Alpha release of MariaDB. The GA release is 10.6.4

Release notes: https://mariadb.com/kb/en/mariadb-1064-release-notes/