### PR TITLE
Add s390x to build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ arch:
   - amd64
   - arm64
   - ppc64le
+  - s390x
 
 os: linux
 
@@ -43,7 +44,7 @@ deploy:
     edge: true
     script: docker run --rm --privileged linuxkit/binfmt:v0.8 &&
       docker buildx create --use &&
-      docker buildx build --platform linux/amd64,linux/arm64/v8,linux/ppc64le -t appwrite/mariadb:$TRAVIS_TAG ./ --push
+      docker buildx build --platform linux/amd64,linux/arm64/v8,linux/ppc64le,linux/s390x -t appwrite/mariadb:$TRAVIS_TAG ./ --push
     on:
       tags: true
       condition: "$TRAVIS_CPU_ARCH = amd64"

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ docker push appwrite/mariadb:1.3.0
 Multi-arch build (experimental using [buildx](https://github.com/docker/buildx)):
 
 ```
-docker buildx build --platform linux/amd64,linux/arm64/v8,linux/ppc64le --tag appwrite/mariadb:1.3.0 --push .
+docker buildx build --platform linux/amd64,linux/arm64/v8,linux/ppc64le,linux/s390x --tag appwrite/mariadb:1.3.0 --push .
 ```
 
 ## Find Us


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Adds s390x support to generated images.

## Test Plan

Look at travis output for s390x build.

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

Was obviously missing from https://github.com/appwrite/appwrite/blob/main/docs/tutorials/multi-architecture-support.md when it was supported upstream.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Honestly, only skimmed through it.