### PR TITLE
compose update

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,11 +13,12 @@ services:
     ports:
       - "3307:3306"
     environment:
-      - MYSQL_ROOT_PASSWORD=rootsecretpassword
-      - MYSQL_DATABASE=appwrite
-      - MYSQL_USER=user
-      - MYSQL_PASSWORD=password
-    command: 'mysqld --innodb-flush-method=fsync'
+      - MARIADB_ROOT_PASSWORD=rootsecretpassword
+      - MARIADB_DATABASE=appwrite
+      - MARIADB_USER=user
+      - MARIADB_PASSWORD=password
+      - MARIADB_AUTO_UPGRADE=1
+    command: '--innodb-flush-method=fsync'
 
 networks:
   db:


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Use MARIADB environment names.

Add MARIADB_AUTO_UPGRADE=1 so mariadb-upgrade is automaticly run if needed.

Remove "mysqld" from command, its not needed, and once it get to mariadb:11.0 it actually won't work.

## Test Plan

`docker compose up`
(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

A little bit more than before.